### PR TITLE
use findProperty() to access properties

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -6,15 +6,15 @@ plugins {
     id("kotlin-parcelize")
 }
 
-val composeVersion = properties["version.compose"] as String
+val composeVersion = findProperty("version.compose") as String
 
 android {
-    compileSdk = (properties["android.compileSdk"] as String).toInt()
+    compileSdk = (findProperty("android.compileSdk") as String).toInt()
 
     defaultConfig {
-        minSdk = (properties["android.minSdk"] as String).toInt()
-        targetSdk = (properties["android.targetSdk"] as String).toInt()
-        buildToolsVersion = properties["android.buildToolsVersion"] as String
+        minSdk = (findProperty("android.minSdk") as String).toInt()
+        targetSdk = (findProperty("android.targetSdk") as String).toInt()
+        buildToolsVersion = findProperty("android.buildToolsVersion") as String
 
         applicationId = "com.github.jetbrains.rssreader.androidApp"
         versionCode = 1
@@ -91,7 +91,7 @@ dependencies {
     //UI
     implementation("androidx.appcompat:appcompat:1.3.0-rc01")
     //Coroutines
-    val coroutinesVersion = properties["version.kotlinx.coroutines"]
+    val coroutinesVersion = findProperty("version.kotlinx.coroutines")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
     //DI

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,9 +5,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${properties["version.kotlin"]}")
-        classpath("org.jetbrains.kotlin:kotlin-serialization:${properties["version.kotlin"]}")
-        classpath("com.android.tools.build:gradle:${properties["version.androidGradlePlugin"]}")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${findProperty("version.kotlin")}")
+        classpath("org.jetbrains.kotlin:kotlin-serialization:${findProperty("version.kotlin")}")
+        classpath("com.android.tools.build:gradle:${findProperty("version.androidGradlePlugin")}")
     }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -39,14 +39,14 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 //Network
-                implementation("io.ktor:ktor-client-core:${properties["version.ktor"]}")
-                implementation("io.ktor:ktor-client-logging:${properties["version.ktor"]}")
+                implementation("io.ktor:ktor-client-core:${findProperty("version.ktor")}")
+                implementation("io.ktor:ktor-client-logging:${findProperty("version.ktor")}")
                 //Coroutines
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${properties["version.kotlinx.coroutines"]}")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${findProperty("version.kotlinx.coroutines")}")
                 //Logger
                 implementation("com.github.aakira:napier:1.4.1")
                 //JSON
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${properties["version.kotlinx.serialization"]}")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${findProperty("version.kotlinx.serialization")}")
                 //Key-Value storage
                 implementation("com.russhwolf:multiplatform-settings:0.7.4")
             }
@@ -55,14 +55,14 @@ kotlin {
         val androidMain by getting {
             dependencies {
                 //Network
-                implementation("io.ktor:ktor-client-okhttp:${properties["version.ktor"]}")
+                implementation("io.ktor:ktor-client-okhttp:${findProperty("version.ktor")}")
             }
         }
 
         val iosMain by getting {
             dependencies {
                 //Network
-                implementation("io.ktor:ktor-client-ios:${properties["version.ktor"]}")
+                implementation("io.ktor:ktor-client-ios:${findProperty("version.ktor")}")
             }
         }
 
@@ -74,11 +74,11 @@ kotlin {
 }
 
 android {
-    compileSdk = (properties["android.compileSdk"] as String).toInt()
+    compileSdk = (findProperty("android.compileSdk") as String).toInt()
 
     defaultConfig {
-        minSdk = (properties["android.minSdk"] as String).toInt()
-        targetSdk = (properties["android.targetSdk"] as String).toInt()
+        minSdk = (findProperty("android.minSdk") as String).toInt()
+        targetSdk = (findProperty("android.targetSdk") as String).toInt()
     }
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 }


### PR DESCRIPTION
This Pull Request fixes #18 and only switches the calls to properties[] to findProperty() as described in this blog post: https://dev.to/jmfayard/configuring-gradle-with-gradle-properties-211k