### PR TITLE
update compose and agp to the latest versions

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -85,9 +85,9 @@ dependencies {
     implementation("androidx.compose.foundation:foundation:$composeVersion")
     implementation("androidx.compose.material:material:$composeVersion")
     //Compose Utils
-    implementation("com.google.accompanist:accompanist-coil:0.8.1")
-    implementation("com.google.accompanist:accompanist-insets:0.8.1")
-    implementation("com.google.accompanist:accompanist-swiperefresh:0.8.1")
+    implementation("com.google.accompanist:accompanist-coil:0.10.0")
+    implementation("com.google.accompanist:accompanist-insets:0.10.0")
+    implementation("com.google.accompanist:accompanist-swiperefresh:0.10.0")
     //UI
     implementation("androidx.appcompat:appcompat:1.3.0-rc01")
     //Coroutines

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ android.buildToolsVersion=30.0.2
 
 #Common versions
 version.kotlin=1.4.32
-version.androidGradlePlugin=7.0.0-alpha15
-version.compose=1.0.0-beta05
+version.androidGradlePlugin=7.0.0-beta02
+version.compose=1.0.0-beta07
 version.kotlinx.serialization=1.1.0
 version.ktor=1.5.2
 version.kotlinx.coroutines=1.4.3-native-mt


### PR DESCRIPTION
Accompanist 0.8.1 -> 0.10.0 (supports Compose Beta 07 https://github.com/google/accompanist/releases/tag/v0.10.0)
Compose Beta 05 -> Beta 07
AGP Alpha 15 -> Beta 02