### PR TITLE
Fix issue running the iOS app on Macbook M1

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     implementation("androidx.compose.material:material:$composeVersion")
     //Compose Utils
     implementation("io.coil-kt:coil-compose:1.4.0")
-    implementation("androidx.activity:activity-compose:1.3.1")
+    implementation("androidx.activity:activity-compose:1.4.0")
     implementation("com.google.accompanist:accompanist-insets:0.20.0")
     implementation("com.google.accompanist:accompanist-swiperefresh:0.20.0")
     //Coroutines

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,9 @@ android.targetSdk=31
 android.minSdk=21
 
 #Common versions
-version.kotlin=1.5.31
+version.kotlin=1.6.0
 version.androidGradlePlugin=7.0.3
-version.compose=1.1.0-alpha06
+version.compose=1.1.0-rc01
 version.kotlinx.serialization=1.3.0
-version.ktor=1.6.4
+version.ktor=1.6.7
 version.kotlinx.coroutines=1.5.2-native-mt

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
     listOf(
         iosX64(),
         iosArm64(),
-        //iosSimulatorArm64() waiting ktor M1 support
+        iosSimulatorArm64()
     ).forEach {
         it.binaries.framework {
             baseName = "RssReader"
@@ -43,12 +43,12 @@ kotlin {
 
         val iosX64Main by getting
         val iosArm64Main by getting
-        //val iosSimulatorArm64Main by getting
+        val iosSimulatorArm64Main by getting
         val iosMain by creating {
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
-            //iosSimulatorArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
             dependencies {
                 //Network
                 implementation("io.ktor:ktor-client-ios:${findProperty("version.ktor")}")


### PR DESCRIPTION
Ktor update is available and running the iOS app on Macbook M1 is possible now by upgrading Ktor to the latest version. I needed to upgrade Kotlin version to be compatible with Ktor version.