### PR TITLE
Set color of iOS status bar to same orange

### DIFF
--- a/iosApp/iosApp/RSSApp.swift
+++ b/iosApp/iosApp/RSSApp.swift
@@ -4,11 +4,14 @@ import ComposeApp
 
 @main
 struct iOSApp: App {
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
-    }
+	var body: some Scene {
+		WindowGroup {
+		    ZStack {
+		        Color(#colorLiteral(red: 0.973, green: 0.529, blue: 0.235, alpha: 1)).ignoresSafeArea(.all)
+			    ContentView()
+			}.preferredColorScheme(.dark)
+		}
+	}
 }
 
 struct ContentView: View {


### PR DESCRIPTION
Same as #60, but now with 90% fewer rogue commits.